### PR TITLE
Fix redhat.properties file

### DIFF
--- a/casestudy/redhat.properties
+++ b/casestudy/redhat.properties
@@ -1,4 +1,4 @@
 postIncludes=usr/lib/gcc/x86_64-redhat-linux/4.4.4/include
-predefMacros=../TypeChef-Sampling-BusyBox/casestudy/platform-redhat.h
-systemRoot=../TypeChef-Sampling-BusyBox/casestudy/systems/redhat
+predefMacros=../TypeChef-Sampling-Busybox/casestudy/platform-redhat.h
+systemRoot=../TypeChef-Sampling-Busybox/casestudy/systems/redhat
 


### PR DESCRIPTION
The redhat.properties file had a capitalization error in it that caused the analysis to fail, which this pull request corrects.